### PR TITLE
add audit-stop command for ATR chandelier stop audit

### DIFF
--- a/src/commands/auditStop.ts
+++ b/src/commands/auditStop.ts
@@ -1,0 +1,359 @@
+import chalk from "chalk";
+import Table from "cli-table3";
+import { Command } from "commander";
+import ora from "ora";
+import { Snaptrade } from "snaptrade-typescript-sdk";
+import { computeChandelierStop } from "../utils/atr.ts";
+import { getLastQuotes } from "../utils/quotes.ts";
+import { loadOrRegisterUser } from "../utils/user.ts";
+
+type StopStatus = "MISSING" | "ADJUST" | "OK";
+
+function isStopOrder(orderType?: string | null): boolean {
+  if (!orderType) return false;
+  const t = orderType.toLowerCase();
+  // Covers "Stop", "StopLimit", "TrailingStop", IBKR's "STP", "STP LMT", "TRAIL"
+  return t.includes("stop") || t === "stp" || t.startsWith("stp ") || t.includes("trail");
+}
+
+function isSellAction(action?: string | null): boolean {
+  if (!action) return false;
+  return action.toUpperCase().startsWith("SELL");
+}
+
+const LIVE_STATUSES = new Set([
+  "NONE",
+  "PENDING",
+  "ACCEPTED",
+  "QUEUED",
+  "TRIGGERED",
+  "ACTIVATED",
+  "PARTIAL",
+  "REPLACE_PENDING",
+  "REPLACED",
+  "CANCEL_PENDING",
+]);
+
+function isLiveStop(status?: string | null): boolean {
+  if (!status) return true; // no status = assume live
+  return LIVE_STATUSES.has(status.toUpperCase());
+}
+
+function formatAccountLabel(account: {
+  name?: string | null;
+  number: string;
+  institution_name?: string | null;
+}): string {
+  const base = `${account.name || "Account"} (${account.number})`;
+  return account.institution_name ? `${base} · ${account.institution_name}` : base;
+}
+
+export function auditStopCommand(snaptrade: Snaptrade): Command {
+  return new Command("audit-stop")
+    .description(
+      "Audit equity holdings against an ATR-based chandelier stop formula"
+    )
+    .option("--atr-period <n>", "ATR period (default 14)", "14")
+    .option(
+      "--lookback <n>",
+      "Highest-close lookback window in trading days (default 22)",
+      "22"
+    )
+    .option("--multiplier <n>", "ATR multiplier (default 3)", "3")
+    .option(
+      "--tolerance <pct>",
+      "Pct drift that flags ADJUST rather than OK (default 5)",
+      "5"
+    )
+    .option("--debug", "Print per-account position/order counts and dropped rows")
+    .option(
+      "--dump-orders",
+      "Dump raw stop-like orders to stdout (useful for broker-specific debugging)"
+    )
+    .action(async (opts) => {
+      const atrPeriod = parseInt(opts.atrPeriod, 10);
+      const lookback = parseInt(opts.lookback, 10);
+      const multiplier = parseFloat(opts.multiplier);
+      const tolerance = parseFloat(opts.tolerance) / 100;
+
+      const user = await loadOrRegisterUser(snaptrade);
+
+      const accounts = (
+        await snaptrade.accountInformation.listUserAccounts(user)
+      ).data;
+
+      if (accounts.length === 0) {
+        console.log("⚠️ No accounts connected.");
+        return;
+      }
+
+      const spinner = ora(
+        `Loading positions and orders... 0/${accounts.length} accounts`
+      ).start();
+
+      let completed = 0;
+      const perAccount = await Promise.all(
+        accounts.map(async (account) => {
+          const [positions, orders] = await Promise.all([
+            snaptrade.accountInformation.getUserAccountPositions({
+              ...user,
+              accountId: account.id,
+            }),
+            snaptrade.accountInformation.getUserAccountOrders({
+              ...user,
+              accountId: account.id,
+              state: "open",
+            }),
+          ]);
+          completed++;
+          spinner.text = `Loading positions and orders... ${completed}/${accounts.length} accounts`;
+          return { account, positions: positions.data, orders: orders.data };
+        })
+      );
+
+      spinner.text = "Computing ATR stops...";
+
+      type Row = {
+        accountLabel: string;
+        symbol: string;
+        quantity: number;
+        currency: string;
+      };
+
+      const rows: Row[] = [];
+      const symbolSet = new Set<string>();
+      const debug: string[] = [];
+      for (const { account, positions, orders } of perAccount) {
+        const accountLabel = formatAccountLabel(account);
+        const stopOrderCount = (orders || []).filter((o) =>
+          isStopOrder(o.order_type)
+        ).length;
+        debug.push(
+          `${accountLabel}: ${positions.length} positions, ${(orders || []).length} open orders (${stopOrderCount} stop)`
+        );
+        const typeCounts = new Map<string, number>();
+        const actionCounts = new Map<string, number>();
+        const statusCounts = new Map<string, number>();
+        let withStopPrice = 0;
+        let withLimitPrice = 0;
+        let withPrice = 0;
+        for (const o of orders || []) {
+          const ot = String(o.order_type ?? "<null>");
+          typeCounts.set(ot, (typeCounts.get(ot) || 0) + 1);
+          const act = String(o.action ?? "<null>");
+          actionCounts.set(act, (actionCounts.get(act) || 0) + 1);
+          const st = String(o.status ?? "<null>");
+          statusCounts.set(st, (statusCounts.get(st) || 0) + 1);
+          if (o.stop_price != null) withStopPrice++;
+          if ((o as { limit_price?: unknown }).limit_price != null)
+            withLimitPrice++;
+          if ((o as { price?: unknown }).price != null) withPrice++;
+        }
+        const fmtCounts = (m: Map<string, number>) =>
+          [...m.entries()].map(([k, v]) => `${k}×${v}`).join(", ");
+        if (typeCounts.size > 0) {
+          debug.push(`  order_type: ${fmtCounts(typeCounts)}`);
+          debug.push(`  action: ${fmtCounts(actionCounts)}`);
+          debug.push(`  status: ${fmtCounts(statusCounts)}`);
+          debug.push(
+            `  populated: stop_price=${withStopPrice}, limit_price=${withLimitPrice}, price=${withPrice}`
+          );
+        }
+        for (const p of positions) {
+          const symbol = p.symbol?.symbol?.symbol;
+          const qty = p.units || 0;
+          if (!symbol) {
+            debug.push(`  SKIP: position with no symbol (units=${qty})`);
+            continue;
+          }
+          if (qty <= 0) {
+            debug.push(`  SKIP ${symbol}: qty=${qty} (short or zero)`);
+            continue;
+          }
+          symbolSet.add(symbol);
+          rows.push({
+            accountLabel,
+            symbol,
+            quantity: qty,
+            currency: p.symbol?.symbol?.currency.code || "USD",
+          });
+        }
+      }
+
+      const symbols = [...symbolSet];
+      const [quotes, stopResults] = await Promise.all([
+        getLastQuotes(symbols),
+        Promise.all(
+          symbols.map(async (s) => [
+            s,
+            await computeChandelierStop({
+              symbol: s,
+              atrPeriod,
+              lookback,
+              multiplier,
+            }),
+          ] as const)
+        ),
+      ]);
+      const stopsBySymbol = Object.fromEntries(stopResults);
+
+      spinner.stop();
+
+      const existingStopBy = new Map<string, number>();
+      const dumpedOrders: unknown[] = [];
+      for (const { account, orders } of perAccount) {
+        if (!orders) continue;
+        for (const order of orders) {
+          if (opts.dumpOrders) dumpedOrders.push(order);
+          const stopLike = isStopOrder(order.order_type);
+          if (!stopLike) continue;
+          if (!isLiveStop(order.status)) {
+            debug.push(
+              `  Skip stop in ${account.number}: status=${order.status} type=${order.order_type}`
+            );
+            continue;
+          }
+          if (!isSellAction(order.action)) {
+            debug.push(
+              `  Skip stop in ${account.number}: action=${order.action} type=${order.order_type}`
+            );
+            continue;
+          }
+          const symbol = order.universal_symbol?.symbol;
+          const stopPrice = order.stop_price;
+          if (!symbol || stopPrice == null) {
+            debug.push(
+              `  Skip stop in ${account.number}: symbol=${symbol} stop=${stopPrice} type=${order.order_type}`
+            );
+            continue;
+          }
+          const key = `${account.id}|${symbol}`;
+          const prev = existingStopBy.get(key);
+          if (prev == null || stopPrice < prev) {
+            existingStopBy.set(key, stopPrice);
+          }
+        }
+      }
+
+      if (opts.dumpOrders) {
+        console.log(chalk.dim("\n--- raw stop-like orders ---"));
+        console.log(JSON.stringify(dumpedOrders, null, 2));
+      }
+
+      const accountIdByLabel = new Map<string, string>();
+      const zeroOrderAccounts = new Set<string>();
+      for (const { account, orders } of perAccount) {
+        const label = formatAccountLabel(account);
+        accountIdByLabel.set(label, account.id);
+        if (!orders || orders.length === 0) {
+          zeroOrderAccounts.add(label);
+        }
+      }
+
+      rows.sort(
+        (a, b) =>
+          a.accountLabel.localeCompare(b.accountLabel) ||
+          a.symbol.localeCompare(b.symbol)
+      );
+
+      const fmt = (value: number | undefined, currency: string) =>
+        value == null
+          ? "N/A"
+          : value.toLocaleString("en-US", { style: "currency", currency });
+
+      const rowsByAccount = new Map<string, Row[]>();
+      for (const row of rows) {
+        const bucket = rowsByAccount.get(row.accountLabel);
+        if (bucket) bucket.push(row);
+        else rowsByAccount.set(row.accountLabel, [row]);
+      }
+
+      let firstTable = true;
+      for (const [accountLabel, accountRows] of rowsByAccount) {
+        const accountId = accountIdByLabel.get(accountLabel)!;
+        const table = new Table({
+          head: [
+            "Symbol",
+            "Qty",
+            "Price",
+            "Target Stop",
+            "Current Stop",
+            "Drift",
+            "Status",
+          ],
+          colAligns: [
+            "left",
+            "right",
+            "right",
+            "right",
+            "right",
+            "right",
+            "left",
+          ],
+        });
+
+        for (const row of accountRows) {
+          const target = stopsBySymbol[row.symbol];
+          const existing = existingStopBy.get(`${accountId}|${row.symbol}`);
+          const quote = quotes[row.symbol];
+
+          let status: StopStatus;
+          let driftLabel = "-";
+          if (existing == null) {
+            status = "MISSING";
+          } else if (target == null) {
+            status = "OK";
+            driftLabel = "no target";
+          } else {
+            const drift = (existing - target.price) / target.price;
+            driftLabel = `${(drift * 100).toFixed(1)}%`;
+            status = Math.abs(drift) <= tolerance ? "OK" : "ADJUST";
+          }
+
+          const statusCell =
+            status === "OK"
+              ? chalk.green(status)
+              : status === "ADJUST"
+                ? chalk.yellow(status)
+                : chalk.red(status);
+
+          table.push([
+            row.symbol,
+            row.quantity,
+            fmt(quote?.last, quote?.currency || row.currency),
+            fmt(target?.price, row.currency),
+            fmt(existing, row.currency),
+            driftLabel,
+            statusCell,
+          ]);
+        }
+
+        if (!firstTable) console.log();
+        firstTable = false;
+        console.log(chalk.bold(accountLabel));
+        if (zeroOrderAccounts.has(accountLabel)) {
+          console.log(
+            chalk.yellow(
+              "  ⚠ SnapTrade returned no open orders for this account — \"Current Stop\" cannot be determined. Verify at your broker directly."
+            )
+          );
+        }
+        console.log(table.toString());
+      }
+      console.log(
+        chalk.dim(
+          `\nFormula: highest_close(${lookback}) − ${multiplier} × ATR(${atrPeriod}). Tolerance: ±${(tolerance * 100).toFixed(0)}%.`
+        )
+      );
+
+      if (opts.debug) {
+        console.log(chalk.dim("\n--- debug ---"));
+        for (const line of debug) console.log(chalk.dim(line));
+        console.log(
+          chalk.dim(
+            `rows=${rows.length} symbols=${symbols.length} stops_indexed=${existingStopBy.size}`
+          )
+        );
+      }
+    });
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,6 +16,7 @@ import { ordersCommand } from "./orders.ts";
 import { instrumentsCommand } from "./instruments.ts";
 import { profilesCommand } from "./profiles.ts";
 import { mcpCommand } from "./mcp.ts";
+import { auditStopCommand } from "./auditStop.ts";
 
 export function registerCommands(program: Command, snaptrade: Snaptrade): void {
   program.addCommand(statusCommand(snaptrade));
@@ -32,6 +33,7 @@ export function registerCommands(program: Command, snaptrade: Snaptrade): void {
   program.addCommand(quoteCommand(snaptrade));
   program.addCommand(tradeCommand(snaptrade));
   program.addCommand(cancelOrderCommand(snaptrade));
+  program.addCommand(auditStopCommand(snaptrade));
   program.addCommand(mcpCommand(snaptrade));
   program.addCommand(profilesCommand());
 }

--- a/src/utils/atr.ts
+++ b/src/utils/atr.ts
@@ -1,0 +1,89 @@
+import { yf } from "./yahooFinance.ts";
+
+export type ChandelierStop = {
+  price: number;
+  atr: number;
+  highestClose: number;
+  lookback: number;
+  multiplier: number;
+  period: number;
+};
+
+export async function computeChandelierStop({
+  symbol,
+  atrPeriod = 14,
+  lookback = 22,
+  multiplier = 3,
+}: {
+  symbol: string;
+  atrPeriod?: number;
+  lookback?: number;
+  multiplier?: number;
+}): Promise<ChandelierStop | undefined> {
+  // Need enough bars for ATR smoothing + the lookback window. Pull ~90 calendar
+  // days which typically gives ~60 trading days — plenty for period=14,
+  // lookback=22.
+  const period2 = new Date();
+  const period1 = new Date(period2);
+  period1.setDate(period1.getDate() - 90);
+
+  let result;
+  try {
+    result = await yf.chart(
+      symbol,
+      { period1, period2, interval: "1d", return: "object" },
+      { validateResult: false }
+    );
+  } catch {
+    return undefined;
+  }
+
+  const quote = (result as any)?.indicators?.quote?.[0];
+  if (!quote) return undefined;
+
+  const highs: number[] = [];
+  const lows: number[] = [];
+  const closes: number[] = [];
+  const n = (quote.close as Array<number | null>).length;
+  for (let i = 0; i < n; i++) {
+    const h = quote.high[i];
+    const l = quote.low[i];
+    const c = quote.close[i];
+    if (h == null || l == null || c == null) continue;
+    highs.push(h);
+    lows.push(l);
+    closes.push(c);
+  }
+
+  if (closes.length < atrPeriod + 1 || closes.length < lookback) {
+    return undefined;
+  }
+
+  // Wilder's ATR
+  const trs: number[] = [];
+  for (let i = 1; i < closes.length; i++) {
+    const tr = Math.max(
+      highs[i] - lows[i],
+      Math.abs(highs[i] - closes[i - 1]),
+      Math.abs(lows[i] - closes[i - 1])
+    );
+    trs.push(tr);
+  }
+  let atr =
+    trs.slice(0, atrPeriod).reduce((sum, tr) => sum + tr, 0) / atrPeriod;
+  for (let i = atrPeriod; i < trs.length; i++) {
+    atr = (atr * (atrPeriod - 1) + trs[i]) / atrPeriod;
+  }
+
+  const recentCloses = closes.slice(-lookback);
+  const highestClose = Math.max(...recentCloses);
+
+  return {
+    price: highestClose - multiplier * atr,
+    atr,
+    highestClose,
+    lookback,
+    multiplier,
+    period: atrPeriod,
+  };
+}


### PR DESCRIPTION
## Summary
New `audit-stop` command that audits equity holdings against an ATR-based chandelier stop formula: `highest_close(lookback) − multiplier × ATR(period)`. Compares the target stop to any working stop order found on the account.

- One table per account, headed with `name (number) · institution_name`.
- Queries `state: "open"` so historical executions don't pollute stop detection.
- Yellow warning under any account where SnapTrade returned zero open orders. SnapTrade's Fidelity and Interactive Brokers integrations surface holdings/executions but not working orders — without the caveat, `MISSING` there would be misleading. Supported brokers (Schwab / Robinhood / Tradier / Alpaca / etc.) are unaffected.
- `--debug` prints per-account `order_type` / action / status distribution and field-population counts, useful when onboarding a new broker integration.
- `--dump-orders` dumps all raw orders for the account.

Flags: `--atr-period`, `--lookback`, `--multiplier`, `--tolerance`, `--debug`, `--dump-orders`.

## Test plan
- [ ] Run against an account at a broker with trading support (Schwab / Robinhood / Tradier / Alpaca) and confirm the Current Stop column populates
- [ ] Run against a Fidelity or IBKR account and confirm the zero-open-orders warning is shown and `MISSING` is surrounded by the broker caveat
- [ ] `--debug` prints distributions and field-population counts per account
- [ ] Target-stop calculation is stable across runs for the same symbol