### PR TITLE
docs: add manpage generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 build
 dist
 .DS_Store
+
+# Generated during build for npm packaging
+man/snaptrade.1

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "bin",
     "dist",
+    "man",
     "package.json",
     "README.md"
   ],
@@ -21,7 +22,7 @@
     "verify": "npm run lint && npm test && npm run build",
     "prebuild": "node scripts/prepare-build.mjs",
     "build": "tsc -p tsconfig.build.json",
-    "postbuild": "mkdir -p dist/utils && cp src/utils/oauthConstants.cjs dist/utils/",
+    "postbuild": "mkdir -p dist/utils man && cp src/utils/oauthConstants.cjs dist/utils/ && node scripts/generate-man.mjs",
     "release": "rm -rf dist && rm -rf build && npm run build && npm version patch && git push && npm publish"
   },
   "repository": "https://github.com/passiv/snaptrade-cli",
@@ -52,5 +53,6 @@
     "typescript-eslint": "^8.14.0",
     "vitest": "^4.1.8"
   },
-  "type": "module"
+  "type": "module",
+  "man": "./man/snaptrade.1"
 }

--- a/scripts/generate-man.mjs
+++ b/scripts/generate-man.mjs
@@ -1,0 +1,44 @@
+import { execFile } from "child_process";
+import { readFile, writeFile } from "fs/promises";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+const packageJson = JSON.parse(await readFile("package.json", "utf-8"));
+
+const { stdout: helpOutput } = await execFileAsync(
+  process.execPath,
+  ["dist/main.js", "--help"],
+  {
+    env: {
+      ...process.env,
+      SNAPTRADE_GENERATING_MANPAGE: "1",
+    },
+  },
+);
+
+function escapeGroffText(text) {
+  return text
+    .replace(/\\/g, "\\e")
+    .split("\n")
+    .map((line) => (line.startsWith(".") || line.startsWith("'") ? `\\&${line}` : line))
+    .join("\n");
+}
+
+const escapedHelpOutput = escapeGroffText(helpOutput.trimEnd());
+
+const manPage = String.raw`.TH SNAPTRADE 1 "" "" "User Commands"
+.SH NAME
+snaptrade \- CLI tool to interact with SnapTrade API
+.SH SYNOPSIS
+.B snaptrade
+.RI [ options ]
+.RI [ command ]
+.SH DESCRIPTION
+.nf
+${escapedHelpOutput}
+.fi
+.SH SEE ALSO
+.BR snaptrade\ --help
+`;
+
+await writeFile("man/snaptrade.1", manPage);

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -43,4 +43,9 @@ describe("CLI invocation", () => {
       }),
     ).resolves.toMatchObject({ stderr: "" });
   });
+
+  it("advertises the generated man page in package metadata", () => {
+    expect(packageJson.man).toBe("./man/snaptrade.1");
+    expect(packageJson.files).toContain("man");
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide a generated man page for the CLI and include it in published packages so users can access standard Unix-style documentation.
- Ensure the man page is produced during the build process and that package metadata advertises the file.

### Description
- Added `scripts/generate-man.mjs` which runs the built CLI with `--help`, escapes the output for groff, and writes `man/snaptrade.1`.
- Updated `package.json` to include `man` in `files`, add a `man` metadata field, and change `postbuild` to create the `man` directory and invoke `node scripts/generate-man.mjs` after build.
- Updated `.gitignore` to ignore the generated `man/snaptrade.1` file and included `man` in the published files list.
- Added a test in `test/bin.test.ts` to assert `packageJson.man` and that `packageJson.files` contains `man`.

### Testing
- Ran the test suite with `vitest` and the updated `test/bin.test.ts` which checks CLI help/version behavior and the new package metadata, and all tests passed.
- Verified the `postbuild` pipeline by invoking the build script locally to ensure `scripts/generate-man.mjs` produces `man/snaptrade.1` (succeeds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cea6a0b90832880b014351de5c816)